### PR TITLE
Update screenutil.dart

### DIFF
--- a/lib/screenutil.dart
+++ b/lib/screenutil.dart
@@ -47,7 +47,7 @@ class ScreenUtil {
     _screenWidth = constraints.maxWidth;
     _screenHeight = constraints.maxHeight;
 
-    ui.Window mediaQuery = ui.window;
+    var mediaQuery = ui.window;
     _pixelRatio = mediaQuery.devicePixelRatio;
     _statusBarHeight = mediaQuery.padding.top;
     _bottomBarHeight = mediaQuery.padding.bottom;


### PR DESCRIPTION
flutter 1.25 : Error: 'Window' isn't a type.