### PR TITLE
Changed window reference

### DIFF
--- a/lib/screenutil.dart
+++ b/lib/screenutil.dart
@@ -4,7 +4,6 @@
  */
 
 import 'package:flutter/material.dart';
-import 'dart:ui' as ui;
 
 class ScreenUtil {
   static const Size defaultSize = Size(1080, 1920);
@@ -43,7 +42,7 @@ class ScreenUtil {
     _screenWidth = constraints.maxWidth;
     _screenHeight = constraints.maxHeight;
 
-    var mediaQuery = ui.window;
+    var mediaQuery = WidgetsBinding.instance.window;
     _pixelRatio = mediaQuery.devicePixelRatio;
     _statusBarHeight = mediaQuery.padding.top;
     _bottomBarHeight = mediaQuery.padding.bottom;


### PR DESCRIPTION
I've changed reference of window object as it is recommended in windows docs.

window.dart
/// Please try to avoid statically referencing this and instead use a
/// binding for dependency resolution such as `WidgetsBinding.instance.window`.

binding.dart
/// Each of these other bindings could individually access a [Window] statically,
/// but that would preclude the ability to test these behaviors with a fake 
/// window for verification purposes.  Therefore, [BindingBase] exposes this
/// [Window] for use by other bindings.  A subclass of [BindingBase], such as
/// [TestWidgetsFlutterBinding], can override this accessor to return a
/// different [Window] implementation, such as a [TestWindow].