### PR TITLE
修复ScreenUtilInit的{}未闭合问题

### DIFF
--- a/lib/screenutil_init.dart
+++ b/lib/screenutil_init.dart
@@ -30,7 +30,7 @@ class ScreenUtilInit extends StatelessWidget {
             designSize: designSize,
             allowFontScaling: allowFontScaling,
           );
-
+        }
         return child;
       },
     );


### PR DESCRIPTION
<img width="477" alt="105789962-520de780-5fbe-11eb-9841-a4ea12ddb514" src="https://user-images.githubusercontent.com/35302658/105793368-f5153000-5fc3-11eb-9546-6e04f0cdfbc8.png">
