### PR TITLE
Support for split screen

### DIFF
--- a/example/ios/Flutter/flutter_export_environment.sh
+++ b/example/ios/Flutter/flutter_export_environment.sh
@@ -1,11 +1,10 @@
 #!/bin/sh
 # This is a generated file; do not edit or check into version control.
-export "FLUTTER_ROOT=/Users/lizhuoyuan/Development/flutter"
-export "FLUTTER_APPLICATION_PATH=/Users/lizhuoyuan/Development/Project/flutter_screenutil/example"
+export "FLUTTER_ROOT=C:\flutter"
+export "FLUTTER_APPLICATION_PATH=C:\Users\Avnish\Downloads\flutter_screenutil\example"
 export "COCOAPODS_PARALLEL_CODE_SIGN=true"
-export "FLUTTER_TARGET=lib/main.dart"
+export "FLUTTER_TARGET=lib\main.dart"
 export "FLUTTER_BUILD_DIR=build"
-export "SYMROOT=${SOURCE_ROOT}/../build/ios"
 export "FLUTTER_BUILD_NAME=1.0.0"
 export "FLUTTER_BUILD_NUMBER=1"
 export "DART_OBFUSCATION=false"

--- a/example/lib/main_zh.dart
+++ b/example/lib/main_zh.dart
@@ -1,3 +1,5 @@
+import 'dart:ui';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 
@@ -50,7 +52,7 @@ class _HomePageState extends State<HomePage> {
                 Container(
                   padding: EdgeInsets.all(ScreenUtil().setWidth(10)),
                   width: 180.w,
-                  height: 200.h,
+                  height: 120.h,
                   color: Colors.red,
                   child: Text(
                     '我的实际宽度:${180.w}dp \n'

--- a/lib/flutter_screenutil.dart
+++ b/lib/flutter_screenutil.dart
@@ -7,6 +7,7 @@ library flutter_screenutil;
 
 import 'dart:math';
 import 'dart:ui' as ui;
+import 'dart:ui';
 
 import 'package:flutter/material.dart';
 

--- a/lib/screenutil_init.dart
+++ b/lib/screenutil_init.dart
@@ -5,28 +5,34 @@ class ScreenUtilInit extends StatelessWidget {
   ScreenUtilInit({
     required this.builder,
     this.designSize = ScreenUtil.defaultSize,
+    this.splitScreenMode = true,
     Key? key,
   }) : super(key: key);
 
   final Widget Function() builder;
+  final bool splitScreenMode;
 
   /// The [Size] of the device in the design draft, in dp
   final Size designSize;
-  BoxConstraints constraints1 = BoxConstraints(maxHeight: 0.0);
 
   @override
   Widget build(BuildContext context) {
     return LayoutBuilder(builder: (_, BoxConstraints constraints) {
-      if (constraints.maxHeight > constraints1.maxHeight) {
-        constraints1 = constraints;
+      if (splitScreenMode) {
+        constraints = BoxConstraints(
+            minHeight: constraints.minHeight,
+            maxHeight: max(constraints.maxHeight, 700),
+            minWidth: constraints.minWidth,
+            maxWidth: constraints.maxWidth);
       }
-      if (constraints1.maxWidth != 0) {
+
+      if (constraints.maxWidth != 0) {
         final Orientation orientation =
-            constraints1.maxWidth > constraints1.maxHeight
+            constraints.maxWidth > constraints.maxHeight
                 ? Orientation.landscape
                 : Orientation.portrait;
         ScreenUtil.init(
-          constraints1,
+          constraints,
           orientation: orientation,
           designSize: designSize,
         );

--- a/lib/screenutil_init.dart
+++ b/lib/screenutil_init.dart
@@ -12,16 +12,21 @@ class ScreenUtilInit extends StatelessWidget {
 
   /// The [Size] of the device in the design draft, in dp
   final Size designSize;
+  BoxConstraints constraints1 = BoxConstraints(maxHeight: 0.0);
 
   @override
   Widget build(BuildContext context) {
     return LayoutBuilder(builder: (_, BoxConstraints constraints) {
-      if (constraints.maxWidth != 0) {
-        final Orientation orientation = constraints.maxWidth > constraints.maxHeight
-            ? Orientation.landscape
-            : Orientation.portrait;
+      if (constraints.maxHeight > constraints1.maxHeight) {
+        constraints1 = constraints;
+      }
+      if (constraints1.maxWidth != 0) {
+        final Orientation orientation =
+            constraints1.maxWidth > constraints1.maxHeight
+                ? Orientation.landscape
+                : Orientation.portrait;
         ScreenUtil.init(
-          constraints,
+          constraints1,
           orientation: orientation,
           designSize: designSize,
         );


### PR DESCRIPTION
On mobile split screen as well on the browser the size of text and height of widget gone invisible because of the constraint applied where the max height decrease to almost 0 hence the size of widget and font size too.

I set constraint minHeight to 700 almost the height of the iPhone 5 screen. Enabling this feature is still the developer's choice.

return ScreenUtilInit(
      designSize: Size(360, 690),
      splitScreenMode: false,  // by default it is true
      builder: () => MaterialApp(
               // material parameters
            )
      );

Without this update


https://user-images.githubusercontent.com/42611371/141676935-f3e33b43-4b7f-48e0-b77d-67db894b8a20.mp4



With this update



https://user-images.githubusercontent.com/42611371/141676941-124f1b96-0b86-48a8-8217-86285eaac820.mp4



