### PR TITLE
Fix .sp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 5.0.1+4
+
+- Fix .sp, Text adaptation according to the smaller of width or height
+
+# 5.0.1+3
+
+- Fix .r
+
 # 5.0.1+2
 
 - Text adaptation no longer considers the height of the screen

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ import 'package:flutter_screenutil/flutter_screenutil.dart';
 	<tr>
 		<td>splitScreenMode</td>
 		<td>bool</td>
-		<td>true</td>
+		<td>false</td>
 		<td>support for split screen</td>
 	</tr>
 </table>

--- a/lib/screen_util.dart
+++ b/lib/screen_util.dart
@@ -84,7 +84,7 @@ class ScreenUtil {
   ///  /// The ratio of actual height to UI design
   double get scaleHeight => _screenHeight / uiSize.height;
 
-  double get scaleText => scaleWidth;
+  double get scaleText => min(scaleWidth, scaleHeight);
 
   /// 根据UI设计的设备宽度适配
   /// 高度也可以根据这个来做适配可以保证不变形,比如你想要一个正方形的时候.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_screenutil
 description: A flutter plugin for adapting screen and font size.Guaranteed to look good on different models
-version: 5.0.1+2
+version: 5.0.1+4
 homepage: https://github.com/OpenFlutter/flutter_screenutil
 
 environment:


### PR DESCRIPTION
Fixes #306

When using `.w` for text adaption, If `scaleHeight<scaleWidth & screenHeight<designHeight`. Text size won't adapt efficiently and could cause an overflow because it should use `.h` in this case to adapt with the smaller screen height.

so, back to the old way "Text adaptation according to the smaller of width or height" would help for this scenario.