### PR TITLE
Remove minTextAdapt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 5.0.3
+
+- remove "minTextAdapt" param, Font adaptation is based on the minimum value of width and height.
+- update readme
+
 # 5.0.2
 
 - add "minTextAdapt" param , Font adaptation is based on the minimum value of width and height or only based on width(default)

--- a/README.md
+++ b/README.md
@@ -79,7 +79,6 @@ class MyApp extends StatelessWidget {
     //Set the fit size (Find your UI design, look at the dimensions of the device screen and fill it in,unit in dp)
     return ScreenUtilInit(
       designSize: Size(360, 690),
-      minTextAdapt: true,
       builder: () => MaterialApp(
         ...
         theme: ThemeData(
@@ -144,7 +143,6 @@ class _HomePageState extends State<HomePage> {
             maxWidth: MediaQuery.of(context).size.width,
             maxHeight: MediaQuery.of(context).size.height),
         designSize: Size(360, 690),
-        minTextAdapt: true,
         orientation: Orientation.portrait);
     return Scaffold();
   }

--- a/README_CN.md
+++ b/README_CN.md
@@ -60,7 +60,6 @@ class MyApp extends StatelessWidget {
     //填入设计稿中设备的屏幕尺寸,单位dp
     return ScreenUtilInit(
       designSize: Size(360, 690),
-      minTextAdapt: true,
       builder: () => MaterialApp(
         debugShowCheckedModeBanner: false,
         title: 'Flutter_ScreenUtil',
@@ -116,7 +115,6 @@ class _HomePageState extends State<HomePage> {
             maxWidth: MediaQuery.of(context).size.width,
             maxHeight: MediaQuery.of(context).size.height),
         designSize: Size(360, 690),
-        minTextAdapt: true,
         orientation: Orientation.portrait);
     return Scaffold();
   }

--- a/README_PT.md
+++ b/README_PT.md
@@ -56,7 +56,6 @@ class MyApp extends StatelessWidget {
     //Set the fit size (Find your UI design, look at the dimensions of the device screen and fill it in,unit in dp)
     return ScreenUtilInit(
       designSize: Size(360, 690),
-      minTextAdapt: true,
       builder: () => MaterialApp(
         ...
         theme: ThemeData(

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -9,7 +9,6 @@ class MyApp extends StatelessWidget {
     //Set the fit size (fill in the screen size of the device in the design) If the design is based on the size of the iPhone6 ​​(iPhone6 ​​750*1334)
     return ScreenUtilInit(
       designSize: Size(360, 690),
-      minTextAdapt: true,
       splitScreenMode: true,
       builder: () => MaterialApp(
         debugShowCheckedModeBanner: false,

--- a/lib/screen_util.dart
+++ b/lib/screen_util.dart
@@ -21,7 +21,6 @@ class ScreenUtil {
   late double _screenHeight;
   late double _statusBarHeight;
   late double _bottomBarHeight;
-  late bool _minTextAdapt;
 
   ScreenUtil._();
 
@@ -34,11 +33,9 @@ class ScreenUtil {
     Orientation orientation = Orientation.portrait,
     Size designSize = defaultSize,
     bool splitScreenMode = false,
-    bool minTextAdapt = false,
   }) {
     _instance = ScreenUtil._()
       ..uiSize = designSize
-      .._minTextAdapt = minTextAdapt
       .._orientation = orientation
       .._screenWidth = constraints.maxWidth
       .._screenHeight = splitScreenMode ? max(constraints.maxHeight, 700) : constraints.maxHeight;
@@ -85,7 +82,7 @@ class ScreenUtil {
   ///  /// The ratio of actual height to UI design
   double get scaleHeight => _screenHeight / uiSize.height;
 
-  double get scaleText => _minTextAdapt ? min(scaleWidth, scaleHeight) : scaleWidth;
+  double get scaleText => min(scaleWidth, scaleHeight);
 
   /// 根据UI设计的设备宽度适配
   /// 高度也可以根据这个来做适配可以保证不变形,比如你想要一个正方形的时候.

--- a/lib/screenutil_init.dart
+++ b/lib/screenutil_init.dart
@@ -6,13 +6,11 @@ class ScreenUtilInit extends StatelessWidget {
     required this.builder,
     this.designSize = ScreenUtil.defaultSize,
     this.splitScreenMode = true,
-    this.minTextAdapt = false,
     Key? key,
   }) : super(key: key);
 
   final Widget Function() builder;
   final bool splitScreenMode;
-  final bool minTextAdapt;
 
   /// The [Size] of the device in the design draft, in dp
   final Size designSize;
@@ -27,8 +25,7 @@ class ScreenUtilInit extends StatelessWidget {
         ScreenUtil.init(constraints,
             orientation: orientation,
             designSize: designSize,
-            splitScreenMode: splitScreenMode,
-            minTextAdapt: minTextAdapt);
+            splitScreenMode: splitScreenMode);
         return builder();
       }
       return Container();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_screenutil
 description: A flutter plugin for adapting screen and font size.Guaranteed to look good on different models
-version: 5.0.2
+version: 5.0.3
 homepage: https://github.com/OpenFlutter/flutter_screenutil
 
 environment:


### PR DESCRIPTION
As Explained in #306,

There's no need for font adaption to be based on width, so `minTextAdapt` parameter isn't needed.
Font adaptation based on the minimum value of width and height is perfect.