### PR TITLE
split screen support with the help of scaling value to min 1

### DIFF
--- a/lib/screen_util.dart
+++ b/lib/screen_util.dart
@@ -76,10 +76,10 @@ class ScreenUtil {
 
   /// 实际尺寸与UI设计的比例
   /// The ratio of actual width to UI design
-  double get scaleWidth => _screenWidth / uiSize.width;
+  double get scaleWidth => max(_screenWidth / uiSize.width, 1);
 
   ///  /// The ratio of actual height to UI design
-  double get scaleHeight => _screenHeight / uiSize.height;
+  double get scaleHeight => max(_screenHeight / uiSize.height, 1);
 
   double get scaleText => min(scaleWidth, scaleHeight);
 

--- a/lib/screenutil_init.dart
+++ b/lib/screenutil_init.dart
@@ -5,12 +5,10 @@ class ScreenUtilInit extends StatelessWidget {
   ScreenUtilInit({
     required this.builder,
     this.designSize = ScreenUtil.defaultSize,
-    this.splitScreenMode = true,
     Key? key,
   }) : super(key: key);
 
   final Widget Function() builder;
-  final bool splitScreenMode;
 
   /// The [Size] of the device in the design draft, in dp
   final Size designSize;
@@ -18,14 +16,6 @@ class ScreenUtilInit extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return LayoutBuilder(builder: (_, BoxConstraints constraints) {
-      if (splitScreenMode) {
-        constraints = BoxConstraints(
-            minHeight: constraints.minHeight,
-            maxHeight: max(constraints.maxHeight, 700),
-            minWidth: constraints.minWidth,
-            maxWidth: constraints.maxWidth);
-      }
-
       if (constraints.maxWidth != 0) {
         final Orientation orientation =
             constraints.maxWidth > constraints.maxHeight


### PR DESCRIPTION
/// The ratio of actual width to UI design
  double get scaleWidth => max(_screenWidth / uiSize.width, 1);

  ///  /// The ratio of actual height to UI design
  double get scaleHeight => max(_screenHeight / uiSize.height, 1);

  double get scaleText => min(scaleWidth, scaleHeight) ;
  
 1) This way we don't need boolean splitScreenMode and minTextAdapt.
 
 2) On Laptops and other devices where the screen device width is large, there text will scale based on HEIGHT on mobile devices it will be scaled based on WIDTH.  (Whatever is minimum).
 
 3) max(_screenWidth / uiSize.width, 1); it will limit the  Width scaling minimum to given design size Width by user(developer).

4)   max(_screenHeight / uiSize.height, 1); it will limit the Height scaling minimum to given design size Height by user(developer).

5) Height only depends on device size, not on window size. So it works like most websites and therefore supports split-screen.
