### PR TITLE
fix defalut value false(splitScreenMode)

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ import 'package:flutter_screenutil/flutter_screenutil.dart';
 	<tr>
 		<td>splitScreenMode</td>
 		<td>bool</td>
-		<td>true</td>
+		<td>false</td>
 		<td>support for split screen</td>
 	</tr>
 	<tr>


### PR DESCRIPTION
flutter_screenutil In 5.3.1 it defaults to false.
Update the readme.
<img width="1258" alt="スクリーンショット 2022-04-06 21 05 41" src="https://user-images.githubusercontent.com/16476224/161970804-7fdfd99e-af7c-48c1-ae27-4844d6ba0dd3.png">

