### PR TITLE
Remove print call in init

### DIFF
--- a/lib/src/screen_util.dart
+++ b/lib/src/screen_util.dart
@@ -82,7 +82,6 @@ class ScreenUtil {
     bool splitScreenMode = false,
     bool minTextAdapt = false,
   }) {
-    print('init called');
     final deviceData = MediaQuery.maybeOf(context).nonEmptySizeOrNull();
 
     deviceSize ??= deviceData?.size ?? designSize;


### PR DESCRIPTION
Thanks for this amazing package ❤️

I was running some widget tests and noticed that the console was spitting out `init called`.

Upon further inspection, I noticed that you probably left this line in there by mistake.