### PR TITLE
Fix BorderRadiusExtension

### DIFF
--- a/lib/src/size_extension.dart
+++ b/lib/src/size_extension.dart
@@ -63,7 +63,7 @@ extension BorderRaduisExtension on BorderRadius {
   /// Creates adapt BorderRadius using r [SizeExtension].
   BorderRadius get r => copyWith(
         bottomLeft: bottomLeft.r,
-        bottomRight: bottomLeft.r,
+        bottomRight: bottomRight.r,
         topLeft: topLeft.r,
         topRight: topRight.r,
       );


### PR DESCRIPTION
Before, when using r extension, bottomRight is copied from `bottomLeft.r` not `bottomRight.r`.
bottomRight should be copyWith `bottomRight.r`