### PR TITLE
Bugfix on flutter_screenutil: ^5.5.4

### DIFF
--- a/lib/src/screenutil_init.dart
+++ b/lib/src/screenutil_init.dart
@@ -58,11 +58,13 @@ class ScreenUtilInit extends StatefulWidget {
 
 class _ScreenUtilInitState extends State<ScreenUtilInit>
     with WidgetsBindingObserver {
-  late MediaQueryData mediaQueryData;
+  MediaQueryData? _mediaQueryData;
 
   bool wrappedInMediaQuery = false;
 
   WidgetsBinding get binding => WidgetsFlutterBinding.ensureInitialized();
+
+  MediaQueryData get mediaQueryData => _mediaQueryData!;
 
   MediaQueryData get newData {
     if (widget.useInheritedMediaQuery) {
@@ -89,17 +91,17 @@ class _ScreenUtilInitState extends State<ScreenUtilInit>
   @override
   void initState() {
     super.initState();
-    mediaQueryData = newData;
+    // mediaQueryData = newData;
     binding.addObserver(this);
   }
 
   @override
   void didChangeMetrics() {
-    final old = mediaQueryData;
+    final old = _mediaQueryData;
     final data = newData;
 
     if (widget.rebuildFactor(old, data)) {
-      mediaQueryData = data;
+      _mediaQueryData = data;
       _updateTree(context as Element);
     }
   }
@@ -107,6 +109,7 @@ class _ScreenUtilInitState extends State<ScreenUtilInit>
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
+    If (_mediaQueryData == null) _mediaQueryData = newData;
     didChangeMetrics();
   }
 

--- a/lib/src/screenutil_init.dart
+++ b/lib/src/screenutil_init.dart
@@ -109,7 +109,7 @@ class _ScreenUtilInitState extends State<ScreenUtilInit>
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    If (_mediaQueryData == null) _mediaQueryData = newData;
+    if (_mediaQueryData == null) _mediaQueryData = newData;
     didChangeMetrics();
   }
 

--- a/lib/src/screenutil_init.dart
+++ b/lib/src/screenutil_init.dart
@@ -97,7 +97,7 @@ class _ScreenUtilInitState extends State<ScreenUtilInit>
 
   @override
   void didChangeMetrics() {
-    final old = _mediaQueryData;
+    final old = _mediaQueryData!;
     final data = newData;
 
     if (widget.rebuildFactor(old, data)) {


### PR DESCRIPTION
From version 5.5.4 the below exception is thrown while building `ScreenUtilInit`

```bash
══╡ EXCEPTION CAUGHT BY WIDGETS LIBRARY ╞═══════════════════════════════════════════════════════════
dependOnInheritedWidgetOfExactType<MediaQuery>() or dependOnInheritedElement() was called before
_ScreenUtilInitState.initState() completed.
When an inherited widget changes, for example if the value of Theme.of() changes, its dependent
widgets are rebuilt. If the dependent widget's reference to the inherited widget is in a constructor
or an initState() method, then the rebuilt dependent widget will not reflect the changes in the
inherited widget.
Typically references to inherited widgets should occur in widget build() methods. Alternatively,
initialization based on inherited widgets can be placed in the didChangeDependencies method, which
is called after initState and whenever the dependencies change thereafter.
```

This PR should resolve issue #434 by ensuring calls to access `MediaQueryData` happen in `didChangeDependencies` or `build` method. If you have better alternatives, do let me know.