### PR TITLE
Replace window.viewConfiguration.geometry to window.physicalGeometry

### DIFF
--- a/lib/src/screen_util.dart
+++ b/lib/src/screen_util.dart
@@ -61,7 +61,7 @@ class ScreenUtil {
     final binding = WidgetsFlutterBinding.ensureInitialized();
     window ??= binding.window;
 
-    if (window.viewConfiguration.geometry.isEmpty) {
+    if (window.physicalGeometry.isEmpty) {
       return Future.delayed(duration, () async {
         binding.deferFirstFrame();
         await ensureScreenSize(window, duration);


### PR DESCRIPTION
FlutterView.viewConfiguration is removed in the actual Flutter version (3.9.0-1.0.pre.48) and shouldn't be used:

Discussion: https://github.com/flutter/flutter/issues/121742#issuecomment-1452157893
MR: https://github.com/flutter/engine/pull/40012