### PR TITLE
推荐使用 useInheritedMediaQuery 为 false

### DIFF
--- a/lib/src/screenutil_init.dart
+++ b/lib/src/screenutil_init.dart
@@ -39,7 +39,7 @@ class ScreenUtilInit extends StatefulWidget {
       this.designSize = ScreenUtil.defaultSize,
       this.splitScreenMode = false,
       this.minTextAdapt = false,
-      this.useInheritedMediaQuery = true,
+      this.useInheritedMediaQuery = false,
       this.scaleByHeight = false})
       : super(key: key);
 
@@ -76,13 +76,15 @@ class _ScreenUtilInitState extends State<ScreenUtilInit>
         wrappedInMediaQuery = true;
         return data;
       }
+    } else {
+      final data = MediaQuery.maybeOf(context);
+
+      if (data != null) {
+        return data;
+      }
     }
 
     return MediaQueryData.fromView(View.of(context));
-  }
-
-  Widget get child {
-    return widget.builder.call(context, widget.child);
   }
 
   _updateTree(Element el) {
@@ -148,7 +150,7 @@ class _ScreenUtilInitState extends State<ScreenUtilInit>
                             widget.designSize.height
                         : deviceSize.width,
                     height: deviceSize.height,
-                    child: child,
+                    child: widget.builder(__context, widget.child),
                   ),
                 ));
           },
@@ -176,7 +178,7 @@ class _ScreenUtilInitState extends State<ScreenUtilInit>
                     widget.designSize.height
                 : deviceSize.width,
             height: deviceSize.height,
-            child: child,
+            child: widget.builder(_context, widget.child),
           ),
         ));
   }


### PR DESCRIPTION
关于使用 CupertinoPageRoute，在键盘弹出时多次 rebuild 的问题研究。

参见如下资料：

https://github.com/flutter/flutter/pull/116090

https://github.com/flutter/flutter/pull/116090#issuecomment-1356014347

- If we did want to avoid rebuilding when MediaQuery changes. We can use MediaQueryData.fromWindow(window) to get value, and using didChangeMetrics to update value and call setState() when it is current page, which will not break current theory and will works fine too.

- Set Scaffold's resizeToAvoidBottomInset to false when you don't need adjust viewInsets, because when resizeToAvoidBottomInset is true, the Scaffold will use MediaQuery.viewInsetsOf to subscribe the changes and rebuild when it changes. So set it to false when this page doesn't need to adjust viewInsets.

- Using Builder to avoid rebuild all things in a page

通过以上实践，我自己的项目已经能做到

- 不监听 MediaQuery 且 resizeToAvoidBottomInset 为 false 键盘弹出不会 rebuild。
- 监听 MediaQuery 或者 resizeToAvoidBottomInset 为 true，在 CupertinoPageRoute 中的页面会  rebuild，但不掉帧。
- (未验证，我认为没有必要) 如果在监听 MediaQuery 或者 resizeToAvoidBottomInset 为 true 的情况下，连 CupertinoPageRoute 都不想 rebuild，似乎可以将 https://api.flutter.dev/flutter/material/MaterialPageRoute/maintainState.html 设置为false。


