### PR TITLE
Add web support

### DIFF
--- a/lib/src/screen_util.dart
+++ b/lib/src/screen_util.dart
@@ -3,7 +3,8 @@
  * email: zhuoyuan93@gmail.com
  */
 
-import 'dart:io';
+import 'package:flutter/foundation.dart' show kIsWeb, defaultTargetPlatform;
+
 import 'dart:math' show min, max;
 import 'dart:ui' as ui show FlutterView;
 
@@ -241,34 +242,40 @@ class ScreenUtil {
   double setSp(num fontSize) =>
       fontSizeResolver?.call(fontSize, _instance) ?? fontSize * scaleText;
 
-  DeviceType deviceType() {
-    DeviceType deviceType;
-    switch (Platform.operatingSystem) {
-      case 'android':
-      case 'ios':
-        deviceType = DeviceType.mobile;
-        if ((orientation == Orientation.portrait && screenWidth < 600) ||
-            (orientation == Orientation.landscape && screenHeight < 600)) {
-          deviceType = DeviceType.mobile;
-        } else {
-          deviceType = DeviceType.tablet;
+  DeviceType deviceType(BuildContext context) {
+    var deviceType = DeviceType.web;
+    final screenWidth = MediaQuery.of(context).size.width;
+    final screenHeight = MediaQuery.of(context).size.height;
+    final orientation = MediaQuery.of(context).orientation;
+
+    if (kIsWeb) {
+      deviceType = DeviceType.web;
+    } else {
+      bool isMobile = defaultTargetPlatform == TargetPlatform.iOS || defaultTargetPlatform == TargetPlatform.android;
+      bool isTablet = (orientation == Orientation.portrait && screenWidth >= 600) || (orientation == Orientation.landscape && screenHeight >= 600);
+
+      if (isMobile) {
+        deviceType = isTablet ? DeviceType.tablet : DeviceType.mobile;
+      } else {
+        switch (defaultTargetPlatform) {
+          case TargetPlatform.linux:
+            deviceType = DeviceType.linux;
+            break;
+          case TargetPlatform.macOS:
+            deviceType = DeviceType.mac;
+            break;
+          case TargetPlatform.windows:
+            deviceType = DeviceType.windows;
+            break;
+          case TargetPlatform.fuchsia:
+            deviceType = DeviceType.fuchsia;
+            break;
+          default:
+            break;
         }
-        break;
-      case 'linux':
-        deviceType = DeviceType.linux;
-        break;
-      case 'macos':
-        deviceType = DeviceType.mac;
-        break;
-      case 'windows':
-        deviceType = DeviceType.windows;
-        break;
-      case 'fuchsia':
-        deviceType = DeviceType.fuchsia;
-        break;
-      default:
-        deviceType = DeviceType.web;
+      }
     }
+
     return deviceType;
   }
 


### PR DESCRIPTION
In Flutter Web, the use of dart:io, which is not allowed, has led to the absence of a web support indication on pub.dev. This has caused a misunderstanding among most people, including myself, that this plugin does not support the web. Therefore, I removed dart:io and replaced the necessary functions with other features that support the web.

<img width="528" alt="스크린샷 2024-02-26 오전 9 36 37" src="https://github.com/OpenFlutter/flutter_screenutil/assets/21379657/21acbe08-8567-40e5-96cd-ae092c9452ab">
<img width="630" alt="스크린샷 2024-02-26 오전 9 58 35" src="https://github.com/OpenFlutter/flutter_screenutil/assets/21379657/d1fd6639-3a7c-4db9-8764-e477b5c5dddf">
